### PR TITLE
Fixed loading of mailables

### DIFF
--- a/src/Mailbook.php
+++ b/src/Mailbook.php
@@ -13,6 +13,8 @@ class Mailbook
      */
     protected Collection $mailables;
 
+    protected bool $hasCollected = false;
+
     public function __construct()
     {
         $this->mailables = collect(); // @phpstan-ignore-line
@@ -39,10 +41,16 @@ class Mailbook
 
     private function collect(): void
     {
+        if ($this->hasCollected) {
+            return;
+        }
+
         $filename = base_path('routes/mailbook.php');
 
         if (file_exists($filename)) {
-            include_once $filename;
+            include $filename;
+
+            $this->hasCollected = true;
         }
     }
 }

--- a/tests/Commands/InstallMailbookCommandTest.php
+++ b/tests/Commands/InstallMailbookCommandTest.php
@@ -45,7 +45,17 @@ it('can collect mails from route file', function () {
 
     $mails = Mailbook::mailables();
 
-    expect($mails)->isNotEmpty();
+    expect($mails)->toHaveCount(1);
+});
+
+it('can will collect mails from route file once', function () {
+    artisan(InstallMailbookCommand::class)->assertSuccessful();
+    require_once base_path('app/Mail/MailbookMail.php');
+
+    Mailbook::mailables();
+    $mails = Mailbook::mailables();
+
+    expect($mails)->toHaveCount(1);
 });
 
 it('can render installable mail', function () {


### PR DESCRIPTION
Instead of using `require_once` to load the route file once we keep track of whether or not the mailables have been loaded. This fixes an issue where if you where using mailbook in your tests it would only collect in the first test.