### PR TITLE
Fix inconsistent faking

### DIFF
--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -15,6 +15,11 @@ class DashboardController
     {
         $mailables = Mailbook::mailables();
 
+        if (function_exists('fake')) {
+            $seed = fake()->randomNumber();
+            fake()->seed($seed);
+        }
+
         /** @var MailableItem $current */
         $current = Mailbook::retrieve(
             class: $request->class(),
@@ -45,6 +50,7 @@ class DashboardController
                 'class' => $current->class(),
                 'variant' => $current->currentVariant()?->slug,
                 'locale' => $locale,
+                's' => $seed ?? null,
             ]),
             'send' => config('mailbook.send'),
             'style' => new HtmlString(File::get(__DIR__.'/../../../resources/dist/mailbook.css')),

--- a/src/Http/Controllers/MailContentController.php
+++ b/src/Http/Controllers/MailContentController.php
@@ -20,6 +20,11 @@ class MailContentController
             abort(404);
         }
 
+        if (function_exists('fake') && $request->has('s')) {
+            // restore faker seed
+            fake()->seed($request->get('s'));
+        }
+
         return $current->content();
     }
 }

--- a/tests/Http/Controllers/DashboardControllerTest.php
+++ b/tests/Http/Controllers/DashboardControllerTest.php
@@ -11,10 +11,12 @@ use Xammie\Mailbook\Tests\Mails\TranslatedMail;
 use Xammie\Mailbook\Tests\Support\User;
 
 it('can render default', function () {
-    $seed = fake()->randomNumber();
-    fake()->seed($seed);
-    $number = fake()->randomNumber();
-    fake()->seed($seed);
+    if (function_exists('fake')) {
+        $seed = fake()->randomNumber();
+        fake()->seed($seed);
+        $number = fake()->randomNumber();
+        fake()->seed($seed);
+    }
 
     Mailbook::add(TestMail::class);
     Mailbook::add(OtherMail::class);
@@ -33,15 +35,17 @@ it('can render default', function () {
                 ],
             ],
             'attachments' => [],
-            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5CTestMail&locale=en&s='.$number,
+            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5CTestMail&locale=en'.(isset($number) ? '&s='.$number : ''),
         ]);
 });
 
 it('can get meta', function () {
-    $seed = fake()->randomNumber();
-    fake()->seed($seed);
-    $number = fake()->randomNumber();
-    fake()->seed($seed);
+    if (function_exists('fake')) {
+        $seed = fake()->randomNumber();
+        fake()->seed($seed);
+        $number = fake()->randomNumber();
+        fake()->seed($seed);
+    }
 
     Mailbook::add(OtherMail::class);
 
@@ -59,7 +63,7 @@ it('can get meta', function () {
                 'Bcc' => ['"Mailbook" <bcc@mailbook.dev>'],
             ],
             'attachments' => [],
-            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5COtherMail&locale=en&s='.$number,
+            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5COtherMail&locale=en'.(isset($number) ? '&s='.$number : ''),
         ]);
 });
 

--- a/tests/Http/Controllers/DashboardControllerTest.php
+++ b/tests/Http/Controllers/DashboardControllerTest.php
@@ -11,6 +11,11 @@ use Xammie\Mailbook\Tests\Mails\TranslatedMail;
 use Xammie\Mailbook\Tests\Support\User;
 
 it('can render default', function () {
+    $seed = fake()->randomNumber();
+    fake()->seed($seed);
+    $number = fake()->randomNumber();
+    fake()->seed($seed);
+
     Mailbook::add(TestMail::class);
     Mailbook::add(OtherMail::class);
 
@@ -28,11 +33,16 @@ it('can render default', function () {
                 ],
             ],
             'attachments' => [],
-            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5CTestMail&locale=en',
+            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5CTestMail&locale=en&s='.$number,
         ]);
 });
 
 it('can get meta', function () {
+    $seed = fake()->randomNumber();
+    fake()->seed($seed);
+    $number = fake()->randomNumber();
+    fake()->seed($seed);
+
     Mailbook::add(OtherMail::class);
 
     get(route('mailbook.dashboard'))
@@ -49,7 +59,7 @@ it('can get meta', function () {
                 'Bcc' => ['"Mailbook" <bcc@mailbook.dev>'],
             ],
             'attachments' => [],
-            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5COtherMail&locale=en',
+            'preview' => 'http://localhost/mailbook/content?class=Xammie%5CMailbook%5CTests%5CMails%5COtherMail&locale=en&s='.$number,
         ]);
 });
 

--- a/tests/Http/Controllers/MailContentControllerTest.php
+++ b/tests/Http/Controllers/MailContentControllerTest.php
@@ -12,7 +12,7 @@ it('can render', function () {
     Mailbook::add(TestMail::class);
     Mailbook::add(OtherMail::class);
 
-    get(route('mailbook.content', ['class' => TestMail::class]))
+    get(route('mailbook.content', ['class' => TestMail::class, 's' => '123']))
         ->assertSuccessful()
         ->assertSeeText('Test mail');
 });


### PR DESCRIPTION
This fixes inconsistent fake values from faker php. When a fake name would be displayed in the subject it would not correspond with the previewed mailable's subject.