### PR TITLE
Fix initialization issues

### DIFF
--- a/src/MailbookServiceProvider.php
+++ b/src/MailbookServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Xammie\Mailbook;
 
+use Illuminate\Mail\MailManager;
 use Illuminate\Support\Facades\Mail;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -21,8 +22,12 @@ class MailbookServiceProvider extends PackageServiceProvider
             ->hasCommand(InstallMailbookCommand::class);
     }
 
-    public function bootingPackage(): void
+    public function packageBooted(): void
     {
-        Mail::extend('mailbook', fn () => new MailbookTransport);
+        $this->app->extend('mail.manager', function (MailManager $manager): MailManager {
+            return $manager->extend('mailbook', function (): MailbookTransport {
+                return new MailbookTransport();
+            });
+        });
     }
 }


### PR DESCRIPTION
Using packageBooted instead of bootingPackage ensures all necessary services and bindings are available.

Rather than directly using the Mail facade, we're extending the mail manager service in the container. This is more reliable because:

- It ensures proper service container binding
- It avoids potential timing issues during the boot process
- It follows Laravel's service provider best practices