### PR TITLE
Load service provider during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ composer.lock
 coverage
 package-lock.json
 phpunit.xml
-testbench.yaml
 vendor
 node_modules
 .php-cs-fixer.cache

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,3 @@ parameters:
     ignoreErrors:
         - identifier: missingType.iterableValue
     noEnvCallsOutsideOfConfig: false
-    bladestan:
-        template_paths:
-            - mailbook:resources/views

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,2 @@
+providers:
+  - Xammie\Mailbook\MailbookServiceProvider


### PR DESCRIPTION
One of the improvements in Bladestan 0.10.0 was that it's using the application Bladeinstance. I realized that the reason that wasn't enough to auto discover blade files in Mailbook was simply that the service provider that configures it was not being loaded by Testbench. This PR changes this by adding the needed config for it, this should also improve the correctness of other tests you run.