### PR TITLE
Remove support for laravel 11 as it has reached end of life

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        laravel: ['11.*', '12.*', '13.*']
+        laravel: ['12.*', '13.*']
         php: [8.2, 8.3, 8.4, 8.5]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: ^9.9
-            carbon: ^2.72.2
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.8.4
@@ -31,8 +28,6 @@ jobs:
             testbench: ^11.0
             carbon: ^3.8.4
         exclude:
-          - laravel: 11.*
-            php: 8.5
           - laravel: 13.*
             php: 8.2
 


### PR DESCRIPTION
The package can still be installed but it might not continue working in the future